### PR TITLE
feat: add CLI watch scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Running the watch scraper
+
+The repository includes a command line utility `scrape_watch_deals.py` that
+aggregates listings from Reddit, eBay and watch forums, then estimates market
+value and an optional AI score.
+
+Set the required API keys and execute the script:
+
+```bash
+export EBAY_CLIENT_ID=<your-ebay-app-id>
+export SCRAPINGBEE_API_KEY=<your-scrapingbee-key>  # optional
+export GROQ_API_KEY=<your-groq-key>                # optional
+
+python scrape_watch_deals.py
+```
+
+The script will print each deal with price comparisons and, when the keys are
+available, an AI-generated score.

--- a/scrape_watch_deals.py
+++ b/scrape_watch_deals.py
@@ -1,0 +1,75 @@
+import os
+import time
+from parsers.reddit_parser import fetch_reddit_deals
+from parsers.forum_parser import scrape_all_forums
+from parsers.ebay_listings_parser import fetch_ebay_listings
+from parsers.ebay_analyzer import EbayAnalyzer
+from parsers.google_shopping_analyzer import GoogleShoppingAnalyzer
+from parsers.ai_analyzer import GroqAnalyzer
+from utils.data_models import standardize_deal, calculate_margin
+
+
+def run_scraper():
+    ebay_client_id = os.environ.get("EBAY_CLIENT_ID")
+    scrapingbee_api_key = os.environ.get("SCRAPINGBEE_API_KEY")
+    groq_api_key = os.environ.get("GROQ_API_KEY")
+
+    ebay_analyzer = EbayAnalyzer(ebay_client_id)
+    gshopping_analyzer = GoogleShoppingAnalyzer(scrapingbee_api_key)
+    groq_analyzer = GroqAnalyzer(groq_api_key)
+
+    print("\n🏁 Avvio scraping fonti...")
+    raw_deals = []
+    raw_deals.extend(fetch_reddit_deals())
+    raw_deals.extend(fetch_ebay_listings(ebay_client_id))
+    raw_deals.extend(scrape_all_forums())
+
+    print(f"\n📃 Trovati {len(raw_deals)} annunci totali. Analisi in corso...")
+    processed_deals = []
+    for raw in raw_deals:
+        deal = standardize_deal(raw)
+        if not deal:
+            continue
+
+        brand = deal.get("brand")
+        ref = deal.get("referenceNumber")
+        query = None
+        if brand and brand != "Unknown":
+            parts = [brand]
+            if ref and ref != "N/A":
+                parts.append(ref)
+            query = " ".join(parts)
+
+        if query:
+            deal["marketPrice"] = ebay_analyzer.calculate_market_price(query)
+            time.sleep(1)
+            deal["retailPrice"] = gshopping_analyzer.find_grey_market_price(query)
+            time.sleep(1)
+            deal["estimatedMarginPercent"] = calculate_margin(
+                deal["listingPrice"], deal.get("marketPrice")
+            )
+            if deal.get("listingPrice") and deal.get("marketPrice"):
+                score, rationale = groq_analyzer.generate_ai_score(deal)
+                deal["aiScore"] = score
+                deal["aiRationale"] = rationale
+                time.sleep(1)
+        processed_deals.append(deal)
+
+    for d in processed_deals:
+        print("\n---")
+        print(f"Titolo: {d['originalTitle']}")
+        print(f"Sorgente: {d['source']} - {d['sourceUrl']}")
+        print(f"Prezzo annuncio: €{d['listingPrice']}")
+        if d.get("marketPrice"):
+            print(f"Prezzo di mercato stimato: €{d['marketPrice']}")
+        if d.get("retailPrice"):
+            print(f"Prezzo retail/grey market: €{d['retailPrice']}")
+        if d.get("estimatedMarginPercent") is not None:
+            print(f"Margine stimato: {d['estimatedMarginPercent']}%")
+        if d.get("aiScore") is not None:
+            print(f"AI Score: {d['aiScore']} ({d.get('aiRationale')})")
+    print("\n✅ Elaborazione completata.")
+
+
+if __name__ == "__main__":
+    run_scraper()


### PR DESCRIPTION
## Summary
- add `scrape_watch_deals.py` for collecting watch listings and computing market values
- document how to run the scraper in README

## Testing
- `python3 -m py_compile scrape_watch_deals.py`
- `python3 scrape_watch_deals.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684ad810d3448328a3cd2110ec625cc3